### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -12,6 +12,7 @@ from typing import List, Dict, Optional, Tuple
 from config import EMBED_COLOR, YTDL_SEARCH_OPTS, YTDL_DIRECT_OPTS
 from config import SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET, USE_SPOTIFY_API
 from config import NEXT_COLOR, BACK_COLOR, COOKIES_FILE, DEBUG_MODE
+from urllib.parse import urlparse
 
 sp: Optional[spotipy.Spotify] = None
 if USE_SPOTIFY_API:
@@ -89,7 +90,11 @@ class Music(commands.Cog):
         self.playing_now: Dict[int, Optional[Tuple[str, str]]] = {}
 
     def is_spotify_url(self, url: str) -> bool:
-        return USE_SPOTIFY_API and "open.spotify.com" in url
+        if not USE_SPOTIFY_API:
+            return False
+        parsed = urlparse(url)
+        host = parsed.hostname
+        return host == "open.spotify.com"
 
     async def extract_spotify_titles(self, url: str) -> List[str]:
         if not sp:


### PR DESCRIPTION
Potential fix for [https://github.com/cotamilhas/discord-bot/security/code-scanning/1](https://github.com/cotamilhas/discord-bot/security/code-scanning/1)

In general, this should be fixed by parsing the URL and checking its hostname instead of using a substring test on the full URL string. For Spotify, that means: parse with `urllib.parse.urlparse`, inspect the `hostname` field, and verify that it matches `open.spotify.com` (or an allowed set of Spotify hosts) rather than just appearing anywhere in the string.

In this file, the best targeted fix is to update `is_spotify_url` to use `urlparse(url).hostname` and compare it to `"open.spotify.com"`. This preserves existing functionality (it still returns `True` for standard Spotify URLs) while eliminating the incorrect classification of URLs that merely contain the string `open.spotify.com` somewhere else. To implement this, we need to import `urlparse` from Python’s standard library (`urllib.parse`) at the top of `cogs/music.py` and rewrite the body of `is_spotify_url`. All changes are confined to the shown snippet: add the import near the other imports, and modify lines 91–92 to use parsed hostname matching.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
